### PR TITLE
0.1.3/pegasus gate fixes

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -7,7 +7,7 @@
   ],
   "description": "Use ancient artifacts of a long lost race to explore distant lands",
   "networkVersion": "0.0.5",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": {
   },
   "requiredOnClient": true,

--- a/src/Block/BlockStargate.cs
+++ b/src/Block/BlockStargate.cs
@@ -103,7 +103,7 @@ namespace AstriaPorta.Content
 			if (!StargateConfig.Loaded.StargateDestructable) return EnumBlockMaterial.Mantle;
 			if (pos == null)
 			{
-				GateLogger.LogError(LogLevel.Error, "gate block position was null?");
+				GateLogger.LogError(LogLevel.Error, "gate block position was null? (ignore this message during world startup)");
                 return EnumBlockMaterial.Mantle;
             }
 			IStargate gate = GetBlockEntity<StargateBase>(pos);

--- a/src/Block/BlockStargate.cs
+++ b/src/Block/BlockStargate.cs
@@ -109,9 +109,16 @@ namespace AstriaPorta.Content
 			IStargate gate = GetBlockEntity<StargateBase>(pos);
 			if (gate == null)
 			{
-				// gates breaking safety feature
-				FixGateEntity(blockAccessor, pos);
-                return EnumBlockMaterial.Soil;
+                // gates breaking safety feature
+                Block b = blockAccessor.GetBlock(pos);
+				if (b is BlockStargate)
+				{
+                    FixGateEntity(blockAccessor, pos);
+                    return EnumBlockMaterial.Soil;
+                } else
+				{
+					return base.GetBlockMaterial(blockAccessor, pos, stack);
+				}
             }
 
 			if (gate.CanBreak) return EnumBlockMaterial.Metal;
@@ -122,8 +129,13 @@ namespace AstriaPorta.Content
         {
 			if (GetBlockEntity<StargateBase>(pos) == null)
 			{
-				FixGateEntity(blockAccessor, pos);
-				return 1f;
+                // gates breaking safety feature
+                Block b = blockAccessor.GetBlock(pos);
+				if (b is BlockStargate)
+				{
+                    FixGateEntity(blockAccessor, pos);
+                    return 1f;
+                }
 			}
 
             return base.GetResistance(blockAccessor, pos);

--- a/src/BlockEntity/Stargate/Pegasus/PegasusStateManagerClient.cs
+++ b/src/BlockEntity/Stargate/Pegasus/PegasusStateManagerClient.cs
@@ -135,8 +135,8 @@ public class PegasusStateManagerClient : StargateStateManagerClient
         Gate.SoundManager.PauseRotateSound();
         AwaitingChevronAnimation = true;
 
-        Gate.SoundManager.Play(EnumGateSoundLocation.Lock);
         if (CurrentDialSpeed == EnumDialSpeed.Fast) return;
+        Gate.SoundManager.Play(EnumGateSoundLocation.Lock);
 
         Gate.VisualManager.ActivateLockChevron();
         Gate.VisualManager.UpdateChevronGlow(ActiveChevrons + 1);

--- a/src/BlockEntity/Stargate/StateManager/StargateStateManagerBase.cs
+++ b/src/BlockEntity/Stargate/StateManager/StargateStateManagerBase.cs
@@ -219,7 +219,7 @@ public abstract class StargateStateManagerBase : IStargateStateManager
         if (CallbackId != -1)
         {
             Gate.UnregisterDelayedCallback(CallbackId);
-            TickListenerId = -1;
+            CallbackId = -1;
         }
     }
 

--- a/src/BlockEntity/Stargate/StateManager/StargateStateManagerBase.cs
+++ b/src/BlockEntity/Stargate/StateManager/StargateStateManagerBase.cs
@@ -235,7 +235,7 @@ public abstract class StargateStateManagerBase : IStargateStateManager
     public bool WillDialSucceed(IStargateAddress address)
     {
         if (address.AddressBits == Gate.Address.AddressBits) return false;
-        int distanceChunks = Gate.Address.GetDistanceTo(address);
+        int distanceChunks = Gate.Address.GetChunkDistanceTo(address);
         if (distanceChunks < StargateConfig.Loaded.GetMinRangeChunks(Gate.Type)) return false;
         if (distanceChunks > StargateConfig.Loaded.GetMaxRangeChunks(Gate.Type)) return false;
 

--- a/src/BlockEntity/Stargate/StateManager/StargateStateManagerServer.cs
+++ b/src/BlockEntity/Stargate/StateManager/StargateStateManagerServer.cs
@@ -134,6 +134,7 @@ public abstract class StargateStateManagerServer : StargateStateManagerBase
         ActiveChevrons = 0;
         StableConnection = false;
         TimeOpen = 0f;
+        AwaitingChevronAnimation = false;
 
         var remoteGate = Gate.GetRemoteGate();
 
@@ -577,7 +578,6 @@ public abstract class StargateStateManagerServer : StargateStateManagerBase
     {
         GateLogger.LogAudit(LogLevel.Info, $"Started dial to {address} with coordinates ({address.AddressCoordinates.X},{address.AddressCoordinates.Y},{address.AddressCoordinates.Z})");
 
-        // RotationDegPerSecond = StargateConfig.Loaded.DialSpeedDegreesPerSecondMilkyway;
         if (State != EnumStargateState.Idle)
         {
             return false;

--- a/src/BlockEntity/Stargate/StateManager/StargateStateManagerServer.cs
+++ b/src/BlockEntity/Stargate/StateManager/StargateStateManagerServer.cs
@@ -74,6 +74,14 @@ public abstract class StargateStateManagerServer : StargateStateManagerBase
             }
         }
 
+        if (State == EnumStargateState.DialingIncoming || State == EnumStargateState.ConnectedIncoming)
+        {
+            if (!Gate.IsRemoteLoaded)
+            {
+                TryRegisterDelayedCallback(OnRemoteTimeout, (int)(StargateConfig.Loaded.MaxTimeoutSeconds * 1000));
+            }
+        }
+
         SyncStateToClients();
     }
 
@@ -342,7 +350,7 @@ public abstract class StargateStateManagerServer : StargateStateManagerBase
     protected void OnRemoteTimeout(float delta)
     {
         TimeoutCallbackId = -1;
-        if (State == EnumStargateState.DialingOutgoing)
+        if (State == EnumStargateState.DialingOutgoing || State == EnumStargateState.DialingIncoming || State == EnumStargateState.ConnectedIncoming)
         {
             OnConnectionFailure(delta);
             // Gate.TryDisconnect();
@@ -549,6 +557,7 @@ public abstract class StargateStateManagerServer : StargateStateManagerBase
                 }
             }
 
+            remoteGate.EvaluateIncomingConnection(Gate);
             StableConnection = true;
         }
 

--- a/src/Util/IStargateAddress.cs
+++ b/src/Util/IStargateAddress.cs
@@ -44,6 +44,7 @@ namespace AstriaPorta.Util
         public void FromBits(ulong addressBits, ICoreAPI api, int fromDimension = 0);
         public int GetAddressResolution(int mapSize, bool latitude);
         public int GetDistanceTo(IStargateAddress remoteAddres);
+        public int GetChunkDistanceTo(IStargateAddress remoteAddres);
         public void FromTreeAttributes(ITreeAttribute tree);
         public void ToTreeAttributes(ITreeAttribute tree);
     }

--- a/src/Util/StargateAddress.cs
+++ b/src/Util/StargateAddress.cs
@@ -227,9 +227,16 @@ namespace AstriaPorta.Util
 
         public int GetDistanceTo(IStargateAddress remoteAddress)
         {
-            int deltaX = remoteAddress.AddressCoordinates.X - AddressCoordinates.X;
-            int deltaZ = remoteAddress.AddressCoordinates.Z - AddressCoordinates.Z;
+            double deltaX = remoteAddress.AddressCoordinates.X - AddressCoordinates.X;
+            double deltaZ = remoteAddress.AddressCoordinates.Z - AddressCoordinates.Z;
 
+            return (int)Math.Sqrt(deltaX * deltaX + deltaZ * deltaZ);
+        }
+
+        public int GetChunkDistanceTo(IStargateAddress remoteAddress)
+        {
+            double deltaX = (double)((remoteAddress.AddressCoordinates.X - AddressCoordinates.X) / 32);
+            double deltaZ = (double)((remoteAddress.AddressCoordinates.Z - AddressCoordinates.Z) / 32);
             return (int)Math.Sqrt(deltaX * deltaX + deltaZ * deltaZ);
         }
 


### PR DESCRIPTION
#### Fixed:
- Fixed gates crashing when breaking them via anything other than the controller block
- Fixed gates sometimes bricking when cancelling a dial during certain animations
- Fixed pegasus gates playing the lock sound twice
- Fixed an issue in stargate distance calculation for the max possible distance