### PR TITLE
Patch required mining tier being broken due to API changes

### DIFF
--- a/src/Block/BlockDialHomeDevice.cs
+++ b/src/Block/BlockDialHomeDevice.cs
@@ -85,11 +85,11 @@ namespace AstriaPorta.Content
 			return interactions.Append(base.GetPlacedBlockInteractionHelp(world, selection, forPlayer));
 		}
 
-		public override void AddMiningTierInfo(StringBuilder sb)
+		public override void AddMiningTierInfo(StringBuilder sb, IWorldAccessor world, BlockPos pos)
 		{
 			if (!StargateConfig.Loaded.DhdDestructable) return;
 			RequiredMiningTier = StargateConfig.Loaded.DhdMiningTier;
-			base.AddMiningTierInfo(sb);
+			base.AddMiningTierInfo(sb, world, pos);
 		}
 
 		public override EnumBlockMaterial GetBlockMaterial(IBlockAccessor blockAccessor, BlockPos pos, ItemStack stack = null)
@@ -103,5 +103,15 @@ namespace AstriaPorta.Content
 
 			return EnumBlockMaterial.Mantle;
 		}
-	}
+
+        public override int GetRequiredMiningTier(IWorldAccessor world, BlockPos pos)
+        {
+            if (!StargateConfig.Loaded.DhdDestructable)
+            {
+                return base.GetRequiredMiningTier(world, pos);
+            }
+            RequiredMiningTier = StargateConfig.Loaded.DhdMiningTier;
+            return RequiredMiningTier;
+        }
+    }
 }

--- a/src/Block/BlockStargate.cs
+++ b/src/Block/BlockStargate.cs
@@ -91,11 +91,10 @@ namespace AstriaPorta.Content
 			return interactions;
 		}
 
-		public override void AddMiningTierInfo(StringBuilder sb)
+		public override void AddMiningTierInfo(StringBuilder sb, IWorldAccessor world, BlockPos pos)
 		{
 			if (!StargateConfig.Loaded.StargateDestructable) return;
-			RequiredMiningTier = StargateConfig.Loaded.StargateMiningTier;
-			base.AddMiningTierInfo(sb);
+			base.AddMiningTierInfo(sb, world, pos);
 		}
 
 		public override EnumBlockMaterial GetBlockMaterial(IBlockAccessor blockAccessor, BlockPos pos, ItemStack stack = null)
@@ -124,6 +123,17 @@ namespace AstriaPorta.Content
 			if (gate.CanBreak) return EnumBlockMaterial.Metal;
 			return EnumBlockMaterial.Mantle;
 		}
+
+        public override int GetRequiredMiningTier(IWorldAccessor world, BlockPos pos)
+        {
+            if (!StargateConfig.Loaded.StargateDestructable)
+            {
+                return base.GetRequiredMiningTier(world, pos);
+            }
+
+            RequiredMiningTier = StargateConfig.Loaded.StargateMiningTier;
+            return RequiredMiningTier;
+        }
 
         public override float GetResistance(IBlockAccessor blockAccessor, BlockPos pos)
         {

--- a/src/BlockEntity/DHD/BlockEntityDialHomeDevice.cs
+++ b/src/BlockEntity/DHD/BlockEntityDialHomeDevice.cs
@@ -116,7 +116,7 @@ public class BlockEntityDialHomeDevice : BlockEntity, IBlockEntityInteractable, 
         foundGate = targetBlocks.Count > 0 ? targetBlocks[0] : null;
         foreach (var be in targetBlocks)
         {
-            if (Pos.ManhattenDistance(be.Pos) < Pos.ManhattenDistance(foundGate.Pos))
+            if (Pos.ManhattanDistance(be.Pos) < Pos.ManhattanDistance(foundGate.Pos))
             {
                 foundGate = be;
             }


### PR DESCRIPTION
Fixed a mining tier bug caused by an obsolete method, and new mining tier retrieval method added.